### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/kakoune
+* @tinted-theming/kakoune

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 title: "[Bug report] "
 labels: ["bug"]
 assignees: 
-  - base16-project/kakoune
+  - tinted-theming/kakoune
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: "[Feature request] "
 labels: ["feature"]
 assignees: 
-  - base16-project/kakoune
+  - tinted-theming/kakoune
 ---
 
 ## Is your feature request related to a problem? Please describe.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16 colorschemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in kakoune commands:
 
 ```kakoune 
 cd /path/to/base16-kakoune/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-kakoune
@@ -59,8 +59,8 @@ Please follow the instructions in the issue templates:
 - [Issue template for bug reports][5]
 - [Issue template for feature requests][6]
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml
 [4]: .github/pull_request_template.md
 [5]: .github/ISSUE_TEMPLATE/bug_report.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022 Base16 Project
+Copyright (c) 2022 Tinted Theming (https://github.com/tinted-theming)
+Copyright (c) 2022 Jamy Golden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ look like.
 ### [Plug](https://github.com/andreyorst/plug.kak)
 
 ```kak
-plug "base16-project/base16-kakoune" theme config %{
+plug "tinted-theming/base16-kakoune" theme config %{
     colorscheme base16-ocean
 }
 ```
@@ -26,7 +26,7 @@ symlink of `colors` directory. It's recommeded that you symlink the
 
 ```shell
 cd $HOME/.config/kak
-git clone https://github.com/base16-project/base16-kakoune.git
+git clone https://github.com/tinted-theming/base16-kakoune.git
 if [ ! -d "./colors" ]; then mkdir "colors"; fi
 cp ./base16-kakoune/colors/* ./colors
 rm -rf ./base16-kakoune
@@ -36,7 +36,7 @@ rm -rf ./base16-kakoune
 
 ```shell
 cd $HOME/.config
-git clone https://github.com/base16-project/base16-kakoune.git
+git clone https://github.com/tinted-theming/base16-kakoune.git
 ln -s $HOME/.config/base16-kakoune/colors $HOME/.config/kak/colors
 ```
 
@@ -71,8 +71,8 @@ evaluate-commands %sh{
 See [`CONTRIBUTING.md`][4], which contains building and contributing
 instructions.
 
-[1]: https://github.com/base16-project/home
-[2]: https://github.com/base16-project/base16-shell
-[3]: https://base16-project.github.io/base16-gallery/
+[1]: https://github.com/tinted-theming/home
+[2]: https://github.com/tinted-theming/base16-shell
+[3]: https://tinted-theming.github.io/base16-gallery/
 [4]: CONTRIBUTING.md
 [5]: https://kakoune.org/

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,7 +1,7 @@
 # base16-{{scheme-slug}} 
 #
 # Commentary:
-# Base16-project: (https://github.com/base16-project/base16)
+# Tinted Theming: (https://github.com/tinted-theming)
 #
 # Authors:
 # Scheme: {{scheme-author}}


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.